### PR TITLE
Updated baseline README to fix issues encountered when testing.

### DIFF
--- a/baseline/README.md
+++ b/baseline/README.md
@@ -1,6 +1,7 @@
 # Automatic-IGT-Glossing
 
 Train model:
+- First, change the Weights and Biases entity name in token_class_model.py
 
 ```shell
 python3 token_class_model.py train --lang ddo --track open
@@ -9,13 +10,13 @@ python3 token_class_model.py train --lang ddo --track open
 Make predictions:
 
 ```shell
-python3 token_class_model.py predict --lang ddo --track open --pretrained_path ./output --data_path ../../data/Tsez/ddo-dev-track1-covered
+python3 token_class_model.py predict --lang ddo --track open --pretrained_path ./output --encoder_path ./encoder_data.pkl --data_path ../../data/Tsez/ddo-dev-track2-covered
 ```
 
 Eval predictions:
 
 ```shell
-python3 eval.py --pred ./predictions --gold ../../data/Tsez/ddo-train-track1-uncovered
+python3 eval.py --pred ddo_output_preds --gold ../../data/Tsez/ddo-dev-track2-uncovered
 ```
 
 ## Model design

--- a/baseline/src/token_class_model.py
+++ b/baseline/src/token_class_model.py
@@ -98,6 +98,7 @@ languages = {
 @click.option("--data_path", help="The dataset to run predictions on. Only valid in predict mode.", type=click.Path(exists=True))
 def main(mode: str, lang: str, track: str, pretrained_path: str, encoder_path: str, data_path: str):
     if mode == 'train':
+        # Change entity name to your wandb username
         wandb.init(project="igt-generation", entity="michael-ginn")
 
     MODEL_INPUT_LENGTH = 512


### PR DESCRIPTION
	- Added a line to the README about changing the wandb entity name, and a comment in the code showing where to do this.
	- Added the encoder to the prediction command.
	- Changed to track2 in the prediction command, since the open track was specified elsewhere in the command.
	- Changed the location of the predictions in the evaluation command, to reflect where they are stored by the prediction command.
	- Changed to using dev data as the gold standard in the evaluation command (to match predictions).
	- Changed to using track2 as the gold standard in the evaluation command (to match predictions).